### PR TITLE
Rewrite `godep` import path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: go
 go:
-- 1.4.2
+- 1.5
 install:
 - script/bootstrap
 script:

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/jingweno/jqplay",
-	"GoVersion": "go1.4.1",
+	"GoVersion": "go1.5",
 	"Packages": [
 		"./..."
 	],

--- a/Godeps/_workspace/src/github.com/jingweno/negroni-gorelic/example/example.go
+++ b/Godeps/_workspace/src/github.com/jingweno/negroni-gorelic/example/example.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/codegangsta/negroni"
-	"github.com/jingweno/negroni-gorelic"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/codegangsta/negroni"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/jingweno/negroni-gorelic"
 )
 
 func main() {

--- a/Godeps/_workspace/src/github.com/jingweno/negroni-gorelic/gorelic.go
+++ b/Godeps/_workspace/src/github.com/jingweno/negroni-gorelic/gorelic.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/yvasiyarov/go-metrics"
-	"github.com/yvasiyarov/gorelic"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/yvasiyarov/go-metrics"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/yvasiyarov/gorelic"
 )
 
 type Gorelic struct {

--- a/Godeps/_workspace/src/github.com/yvasiyarov/go-metrics/librato/librato.go
+++ b/Godeps/_workspace/src/github.com/yvasiyarov/go-metrics/librato/librato.go
@@ -2,7 +2,7 @@ package librato
 
 import (
 	"fmt"
-	"github.com/yvasiyarov/go-metrics"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/yvasiyarov/go-metrics"
 	"log"
 	"math"
 	"regexp"

--- a/Godeps/_workspace/src/github.com/yvasiyarov/gorelic/agent.go
+++ b/Godeps/_workspace/src/github.com/yvasiyarov/gorelic/agent.go
@@ -3,8 +3,8 @@ package gorelic
 import (
 	"errors"
 	"fmt"
-	metrics "github.com/yvasiyarov/go-metrics"
-	"github.com/yvasiyarov/newrelic_platform_go"
+	metrics "github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/yvasiyarov/go-metrics"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/yvasiyarov/newrelic_platform_go"
 	"log"
 	"net/http"
 )

--- a/Godeps/_workspace/src/github.com/yvasiyarov/gorelic/examples/example1.go
+++ b/Godeps/_workspace/src/github.com/yvasiyarov/gorelic/examples/example1.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	"github.com/yvasiyarov/gorelic"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/yvasiyarov/gorelic"
 	"log"
 	"math/rand"
 	"runtime"

--- a/Godeps/_workspace/src/github.com/yvasiyarov/gorelic/examples/example_web.go
+++ b/Godeps/_workspace/src/github.com/yvasiyarov/gorelic/examples/example_web.go
@@ -3,7 +3,7 @@ package main
 import (
 	"expvar"
 	"flag"
-	"github.com/yvasiyarov/gorelic"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/yvasiyarov/gorelic"
 	"io"
 	"log"
 	"math/rand"

--- a/Godeps/_workspace/src/github.com/yvasiyarov/gorelic/gc_metrics.go
+++ b/Godeps/_workspace/src/github.com/yvasiyarov/gorelic/gc_metrics.go
@@ -1,8 +1,8 @@
 package gorelic
 
 import (
-	metrics "github.com/yvasiyarov/go-metrics"
-	"github.com/yvasiyarov/newrelic_platform_go"
+	metrics "github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/yvasiyarov/go-metrics"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/yvasiyarov/newrelic_platform_go"
 	"time"
 )
 

--- a/Godeps/_workspace/src/github.com/yvasiyarov/gorelic/gometrica.go
+++ b/Godeps/_workspace/src/github.com/yvasiyarov/gorelic/gometrica.go
@@ -2,7 +2,7 @@ package gorelic
 
 import (
 	"fmt"
-	metrics "github.com/yvasiyarov/go-metrics"
+	metrics "github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/yvasiyarov/go-metrics"
 )
 
 const (

--- a/Godeps/_workspace/src/github.com/yvasiyarov/gorelic/http_metrics.go
+++ b/Godeps/_workspace/src/github.com/yvasiyarov/gorelic/http_metrics.go
@@ -1,8 +1,8 @@
 package gorelic
 
 import (
-	metrics "github.com/yvasiyarov/go-metrics"
-	"github.com/yvasiyarov/newrelic_platform_go"
+	metrics "github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/yvasiyarov/go-metrics"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/yvasiyarov/newrelic_platform_go"
 	"net/http"
 	"time"
 )

--- a/Godeps/_workspace/src/github.com/yvasiyarov/gorelic/memory_metrics.go
+++ b/Godeps/_workspace/src/github.com/yvasiyarov/gorelic/memory_metrics.go
@@ -1,8 +1,8 @@
 package gorelic
 
 import (
-	metrics "github.com/yvasiyarov/go-metrics"
-	"github.com/yvasiyarov/newrelic_platform_go"
+	metrics "github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/yvasiyarov/go-metrics"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/yvasiyarov/newrelic_platform_go"
 	"time"
 )
 

--- a/Godeps/_workspace/src/github.com/yvasiyarov/gorelic/runtime_metrics.go
+++ b/Godeps/_workspace/src/github.com/yvasiyarov/gorelic/runtime_metrics.go
@@ -2,7 +2,7 @@ package gorelic
 
 import (
 	"fmt"
-	"github.com/yvasiyarov/newrelic_platform_go"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/yvasiyarov/newrelic_platform_go"
 	"io/ioutil"
 	"os"
 	"runtime"

--- a/Godeps/_workspace/src/github.com/yvasiyarov/newrelic_platform_go/examples/wave_plugin.go
+++ b/Godeps/_workspace/src/github.com/yvasiyarov/newrelic_platform_go/examples/wave_plugin.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/yvasiyarov/newrelic_platform_go"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/yvasiyarov/newrelic_platform_go"
 )
 
 type WaveMetrica struct {

--- a/Godeps/_workspace/src/golang.org/x/net/context/withtimeout_test.go
+++ b/Godeps/_workspace/src/golang.org/x/net/context/withtimeout_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	"golang.org/x/net/context"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/golang.org/x/net/context"
 )
 
 func ExampleWithTimeout() {

--- a/Godeps/_workspace/src/gopkg.in/unrolled/secure.v1/secure_integration_test.go
+++ b/Godeps/_workspace/src/gopkg.in/unrolled/secure.v1/secure_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/codegangsta/negroni"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/codegangsta/negroni"
 )
 
 func TestIntegration(t *testing.T) {

--- a/jq/jq.go
+++ b/jq/jq.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jingweno/jqpipe-go"
-	"golang.org/x/net/context"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/jingweno/jqpipe-go"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/golang.org/x/net/context"
 )
 
 const jqExecTimeout = 3

--- a/script/build
+++ b/script/build
@@ -5,5 +5,5 @@
 
 set -e
 
-./script/godep go build -o ./bin/jqplay
+go build -o ./bin/jqplay
 grunt build

--- a/server/cors.go
+++ b/server/cors.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/codegangsta/negroni"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/codegangsta/negroni"
 )
 
 func corsMiddleware(pathPrefix string) negroni.Handler {

--- a/server/handler.go
+++ b/server/handler.go
@@ -7,8 +7,8 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/gopkg.in/unrolled/render.v1"
 	"github.com/jingweno/jqplay/jq"
-	"gopkg.in/unrolled/render.v1"
 )
 
 const (

--- a/server/robots.go
+++ b/server/robots.go
@@ -3,7 +3,7 @@ package server
 import (
 	"net/http"
 
-	"github.com/codegangsta/negroni"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/codegangsta/negroni"
 )
 
 const robotsPath = "/robots.txt"

--- a/server/secure.go
+++ b/server/secure.go
@@ -3,8 +3,8 @@ package server
 import (
 	"fmt"
 
-	"github.com/codegangsta/negroni"
-	"gopkg.in/unrolled/secure.v1"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/codegangsta/negroni"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/gopkg.in/unrolled/secure.v1"
 )
 
 func secureMiddleware(c *Config) negroni.Handler {

--- a/server/server.go
+++ b/server/server.go
@@ -4,10 +4,10 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/codegangsta/negroni"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/codegangsta/negroni"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/github.com/jingweno/negroni-gorelic"
+	"github.com/jingweno/jqplay/Godeps/_workspace/src/gopkg.in/unrolled/render.v1"
 	"github.com/jingweno/jqplay/jq"
-	"github.com/jingweno/negroni-gorelic"
-	"gopkg.in/unrolled/render.v1"
 )
 
 func New(c *Config) *Server {


### PR DESCRIPTION
This includes changes to rewrite `godep`'s import paths. It also upgrade to Go 1.5