### PR TITLE
Escape shell quotes (') properly for POSIX shells

### DIFF
--- a/assets/js/controllers.js
+++ b/assets/js/controllers.js
@@ -27,7 +27,7 @@ angular.module('jqplay.controllers', []).controller('JqplayCtrl', function Jqpla
     })
     var q = jq.q || ''
 
-    return cmd + "'" + q + "'"
+    return cmd + "'" + q.replace(/'/g, "'\\''") + "'" // use POSIX shell's strong quoting rules
   }
 
   $scope.$watch('jq', function(newValue, oldValue) {


### PR DESCRIPTION
Before this fix, for a jq filter `.["'"]` the given command on the website would result in a Syntax Error in a POSIX-compliant shell, such as bash:
![before](https://s3.baraniecki.eu/jqplay_before_fix.png)
```bash
$ jq '.["'"]'
\`dquote> 
```


After this change, the generated command works correctly:
![after](https://s3.baraniecki.eu/jqplay_after_fix.png)
```bash
$ jq '.["'\''"]'
{"'": "test"}
"test"
```